### PR TITLE
Rename packages

### DIFF
--- a/cliapp/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/cli/CIApplication.kt
+++ b/cliapp/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/cli/CIApplication.kt
@@ -1,14 +1,14 @@
-package org.wycliffeassociates.resourcecontainer.media.cli
+package org.wycliffeassociates.rcmediadownloader.cli
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import java.io.File
-import org.wycliffeassociates.resourcecontainer.media.RCMediaDownloader
-import org.wycliffeassociates.resourcecontainer.media.data.MediaDivision
-import org.wycliffeassociates.resourcecontainer.media.data.MediaType
-import org.wycliffeassociates.resourcecontainer.media.data.MediaUrlParameter
-import org.wycliffeassociates.resourcecontainer.media.io.DownloadClient
+import org.wycliffeassociates.rcmediadownloader.RCMediaDownloader
+import org.wycliffeassociates.rcmediadownloader.data.MediaDivision
+import org.wycliffeassociates.rcmediadownloader.data.MediaType
+import org.wycliffeassociates.rcmediadownloader.data.MediaUrlParameter
+import org.wycliffeassociates.rcmediadownloader.io.DownloadClient
 
 class CIApplication : CliktCommand() {
     private val rcPath by option(

--- a/cliapp/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/cli/Main.kt
+++ b/cliapp/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/cli/Main.kt
@@ -1,3 +1,3 @@
-package org.wycliffeassociates.resourcecontainer.media.cli
+package org.wycliffeassociates.rcmediadownloader.cli
 
 fun main(args: Array<String>) = CIApplication().main(args)

--- a/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/BookMediaDownloader.kt
+++ b/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/BookMediaDownloader.kt
@@ -1,10 +1,10 @@
-package org.wycliffeassociates.resourcecontainer.media
+package org.wycliffeassociates.rcmediadownloader
 
 import java.io.File
+import org.wycliffeassociates.rcmediadownloader.data.MediaDivision
+import org.wycliffeassociates.rcmediadownloader.data.MediaUrlParameter
+import org.wycliffeassociates.rcmediadownloader.io.IDownloadClient
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
-import org.wycliffeassociates.resourcecontainer.media.data.MediaDivision
-import org.wycliffeassociates.resourcecontainer.media.data.MediaUrlParameter
-import org.wycliffeassociates.resourcecontainer.media.io.IDownloadClient
 
 class BookMediaDownloader(
     urlParams: MediaUrlParameter,

--- a/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/ChapterMediaDownloader.kt
+++ b/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/ChapterMediaDownloader.kt
@@ -1,11 +1,11 @@
-package org.wycliffeassociates.resourcecontainer.media
+package org.wycliffeassociates.rcmediadownloader
 
 import java.io.File
 import java.util.stream.Collectors
+import org.wycliffeassociates.rcmediadownloader.data.MediaDivision
+import org.wycliffeassociates.rcmediadownloader.data.MediaUrlParameter
+import org.wycliffeassociates.rcmediadownloader.io.IDownloadClient
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
-import org.wycliffeassociates.resourcecontainer.media.data.MediaDivision
-import org.wycliffeassociates.resourcecontainer.media.data.MediaUrlParameter
-import org.wycliffeassociates.resourcecontainer.media.io.IDownloadClient
 
 class ChapterMediaDownloader(
     urlParams: MediaUrlParameter,

--- a/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/RCMediaDownloader.kt
+++ b/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/RCMediaDownloader.kt
@@ -1,13 +1,13 @@
-package org.wycliffeassociates.resourcecontainer.media
+package org.wycliffeassociates.rcmediadownloader
 
 import java.io.File
 import java.net.MalformedURLException
 import java.net.URL
 import org.slf4j.LoggerFactory
+import org.wycliffeassociates.rcmediadownloader.data.MediaDivision
+import org.wycliffeassociates.rcmediadownloader.data.MediaUrlParameter
+import org.wycliffeassociates.rcmediadownloader.io.IDownloadClient
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
-import org.wycliffeassociates.resourcecontainer.media.data.MediaDivision
-import org.wycliffeassociates.resourcecontainer.media.data.MediaUrlParameter
-import org.wycliffeassociates.resourcecontainer.media.io.IDownloadClient
 
 abstract class RCMediaDownloader(
     val urlParams: MediaUrlParameter,

--- a/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/data/MediaDivision.kt
+++ b/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/data/MediaDivision.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.resourcecontainer.media.data
+package org.wycliffeassociates.rcmediadownloader.data
 
 enum class MediaDivision {
     BOOK,

--- a/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/data/MediaType.kt
+++ b/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/data/MediaType.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.resourcecontainer.media.data
+package org.wycliffeassociates.rcmediadownloader.data
 
 enum class MediaType {
     WAV,

--- a/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/data/MediaUrlParameter.kt
+++ b/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/data/MediaUrlParameter.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.resourcecontainer.media.data
+package org.wycliffeassociates.rcmediadownloader.data
 
 data class MediaUrlParameter(
     val projectId: String,

--- a/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/io/DownloadClient.kt
+++ b/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/io/DownloadClient.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.resourcecontainer.media.io
+package org.wycliffeassociates.rcmediadownloader.io
 
 import java.io.BufferedInputStream
 import java.io.File

--- a/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/io/IDownloadClient.kt
+++ b/lib/src/main/kotlin/org/wycliffeassociates/rcmediadownloader/io/IDownloadClient.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.resourcecontainer.media.io
+package org.wycliffeassociates.rcmediadownloader.io
 
 import java.io.File
 

--- a/lib/src/test/kotlin/org/wycliffeassociates/rcmediadownloader/DownloadMediaToRCTest.kt
+++ b/lib/src/test/kotlin/org/wycliffeassociates/rcmediadownloader/DownloadMediaToRCTest.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.resourcecontainer.media
+package org.wycliffeassociates.rcmediadownloader
 
 import java.io.File
 import java.io.FileNotFoundException
@@ -11,11 +11,11 @@ import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.slf4j.LoggerFactory
+import org.wycliffeassociates.rcmediadownloader.data.MediaDivision
+import org.wycliffeassociates.rcmediadownloader.data.MediaType
+import org.wycliffeassociates.rcmediadownloader.data.MediaUrlParameter
+import org.wycliffeassociates.rcmediadownloader.io.IDownloadClient
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
-import org.wycliffeassociates.resourcecontainer.media.data.MediaDivision
-import org.wycliffeassociates.resourcecontainer.media.data.MediaType
-import org.wycliffeassociates.resourcecontainer.media.data.MediaUrlParameter
-import org.wycliffeassociates.resourcecontainer.media.io.IDownloadClient
 
 class DownloadMediaToRCTest {
     private val logger = LoggerFactory.getLogger(javaClass)


### PR DESCRIPTION
Moves the packages from resourcecontainer to rcmediadownloader.

This library is not part of the resource container library and should not collide with the namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wycliffeassociates/rc_mediadownloader/11)
<!-- Reviewable:end -->
